### PR TITLE
Add blog posts

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -16,7 +16,7 @@ jobs:
           feed_list: "https://plank.co/en/feed/"
           max_post_count: 5
           commit_message: "chore: updated README with latest main blog posts"
-          custom_tags: "MAIN"
+          comment_tag_name: "PLANK"
   
   update-dev-blog:
     name: Update README with DEV blog posts
@@ -28,4 +28,4 @@ jobs:
           feed_list: "https://dev.to/feed/plank"
           max_post_count: 5
           commit_message: "chore: updated README with latest DEV blog posts"
-          custom_tags: "DEV"
+          comment_tag_name: "DEV"

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,31 @@
+name: Update Org Profile README with Latest Blog Posts
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # every day at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update-main-blog:
+    name: Update README with main blog posts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/blog-post-workflow@master
+        with:
+          feed_list: "https://plank.co/en/feed/"
+          max_post_count: 5
+          commit_message: "chore: updated README with latest main blog posts"
+          custom_tags: "MAIN"
+  
+  update-dev-blog:
+    name: Update README with DEV blog posts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/blog-post-workflow@master
+        with:
+          feed_list: "https://dev.to/feed/plank"
+          max_post_count: 5
+          commit_message: "chore: updated README with latest DEV blog posts"
+          custom_tags: "DEV"

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,21 +1,19 @@
 ## Hi there, we're Plank 👋
 
-<!--
-
-**Here are some ideas to get you started:**
-
-🙋‍♀️ A short introduction - what is your organization all about?
-🌈 Contribution guidelines - how can the community get involved?
-👩‍💻 Useful resources - where can the community find your docs? Is there anything else the community should know?
-🍿 Fun facts - what does your team eat for breakfast?
-🧙 Remember, you can do mighty things with the power of [Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
--->
-
-
 <a href="https://plank.co/open-source/learn-more-image">
-    <img src="https://plank.co/open-source/banner">
+    <img src="https://plank.co/open-source/banner" alt="Learn more about our services" />
 </a>
 
 &nbsp;
 
 Plank focuses on impactful solutions that deliver engaging experiences to our clients and their users. We're committed to innovation, inclusivity, and sustainability in the digital space. [Learn more](https://plank.co/open-source/learn-more-link) about our mission to improve the web.
+
+---
+
+## Latest from Our Main Blog
+<!-- BLOG-POST-LIST:MAIN-START -->
+<!-- BLOG-POST-LIST:MAIN-END -->
+
+## Latest from Our DEV Blog
+<!-- BLOG-POST-LIST:DEV-START -->
+<!-- BLOG-POST-LIST:DEV-END -->

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
 ## Hi there, we're Plank 👋
 
 <a href="https://plank.co/open-source/learn-more-image">
-    <img src="https://plank.co/open-source/banner" alt="Learn more about our services" />
+    <img src="https://plank.co/open-source/banner" alt="Toughtful and elegant websites made by dedicated digital craftspeople" />
 </a>
 
 &nbsp;

--- a/profile/README.md
+++ b/profile/README.md
@@ -11,9 +11,9 @@ Plank focuses on impactful solutions that deliver engaging experiences to our cl
 ---
 
 ## Latest from Our Main Blog
-<!-- BLOG-POST-LIST:MAIN-START -->
-<!-- BLOG-POST-LIST:MAIN-END -->
+<!-- PLANK:START -->
+<!-- PLANK:END -->
 
 ## Latest from Our DEV Blog
-<!-- BLOG-POST-LIST:DEV-START -->
-<!-- BLOG-POST-LIST:DEV-END -->
+<!-- DEV:START -->
+<!-- DEV:END -->

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,10 +10,7 @@ Plank focuses on impactful solutions that deliver engaging experiences to our cl
 
 ---
 
-## Latest from Our Main Blog
+## Latest from our blog
 <!-- PLANK:START -->
 <!-- PLANK:END -->
-
-## Latest from Our DEV Blog
-<!-- DEV:START -->
-<!-- DEV:END -->
+*


### PR DESCRIPTION
Little rainy day lunchtime chatgpt github workflow experiment to see about adding blog posts to the org readm. i'd seen it on someone's profile a little ways back and wanted to try for an org.

---

This pull request introduces an automated workflow to keep the organization profile README up to date with the latest blog posts from both the main blog and DEV blog. It also updates the README to display these blog posts dynamically.

**Automation and workflow improvements:**

* Added a new GitHub Actions workflow (`.github/workflows/update-readme.yml`) that runs daily and on demand to update the README with the latest posts from the main blog and DEV blog using the `blog-post-workflow` action.

**README enhancements:**

* Updated `profile/README.md` to include new sections for "Latest from Our Main Blog" and "Latest from Our DEV Blog", with placeholders for automated blog post lists.
* Improved accessibility for the banner image by adding an `alt` attribute.